### PR TITLE
Projectile2

### DIFF
--- a/src/Items/projectile.ts
+++ b/src/Items/projectile.ts
@@ -1,0 +1,23 @@
+import Item from './Item';
+import * as Assets from '../assets';
+export default class Projectile extends Item {
+    /**
+     *
+     */
+    private projectileSpritesheet: Phaser.Sprite = null;
+
+    constructor(game) {
+        super();
+        this.ImageHeight = 31;
+        this.ImageWidth = 31;
+        // let center = super.GetImageCenter(game.world.centerX, game.world.centerY);
+        this.projectileSpritesheet = game.add.sprite(
+            game.world.centerX,
+            game.world.centerY,
+            Assets.Spritesheets.SpritesheetsProjectileSprites.getName()
+        );
+        this.projectileSpritesheet.anchor.setTo(0.5, 0.5);
+        this.projectileSpritesheet.animations.add('projectile', [56]);
+        this.projectileSpritesheet.animations.play('projectile', 30, true);
+    }
+}

--- a/src/Items/spaceship.ts
+++ b/src/Items/spaceship.ts
@@ -10,8 +10,8 @@ export default class Spaceship extends Item {
         super();
         this.ImageHeight = 64;
         this.ImageWidth = 64;
-        let center = super.GetImageCenter(game.world.centerX, game.world.centerY);
-        this._spaceshipImage = game.add.image(center.x, center.y, Assets.Images.ImagesSpaceship.getName());
+        // let center = super.GetImageCenter(game.world.centerX, game.world.centerY);
+        this._spaceshipImage = game.add.image(game.world.centerX, game.world.centerY, Assets.Images.ImagesSpaceship.getName());
         this._spaceshipImage.anchor.setTo(0.5, 0.5);
     }
 

--- a/src/states/preloader.ts
+++ b/src/states/preloader.ts
@@ -13,7 +13,7 @@ export default class Preloader extends Phaser.State {
 
         this.loadBarSprite(gameX, gameY, preloadSpritesArrayName);
         this.loadFrameSprite(gameX, gameY, preloadSpritesArrayName);
-        
+
         this.game.load.setPreloadSprite(this.preloadBarSprite);
 
         AssetUtils.Loader.loadAllAssets(this.game, this.startGame, this);

--- a/src/states/title.ts
+++ b/src/states/title.ts
@@ -1,22 +1,22 @@
 import * as Assets from '../assets';
 import Spaceship from '../Items/spaceship';
+import Projectile from '../Items/projectile';
 import Keys from '../Items/Keys';
 
 export default class Title extends Phaser.State {
-    private projectileSpritesheet: Phaser.Sprite = null;
     private spaceship: Spaceship = null;
+    private projectile: Projectile = null;
     private weapon: Phaser.Weapon = null;
     private _keys: Keys = new Keys();
 
     public preload(): void {
 
         this.spaceship = new Spaceship(this.game);
+        this.projectile = new Projectile(this.game);
 
         this._keys.Left = this.game.input.keyboard.addKey(Phaser.Keyboard.LEFT);
 
-
         this._keys.Right = this.game.input.keyboard.addKey(Phaser.Keyboard.RIGHT);
-
 
         this._keys.Up = this.game.input.keyboard.addKey(Phaser.Keyboard.UP);
         this._keys.Up.onDown.add(this.spaceship.AboutFace, this.spaceship);
@@ -26,17 +26,7 @@ export default class Title extends Phaser.State {
 
         this._keys.Fire = this.game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR);
 
-
-        let gameX: number = this.game.world.centerX;
-        let gameY: number = this.game.world.centerY;
-        this.addProjectiles(gameX, gameY);
-        this.projectileSpritesheet = this.game.add.sprite(
-            gameX,
-            gameY,
-            Assets.Spritesheets.SpritesheetsProjectileSprites.getName()
-        );
-        this.projectileSpritesheet.animations.add('projectile', [56]);
-        this.projectileSpritesheet.animations.play('projectile', 30, true);
+        // this.addProjectiles(gameX, gameY);
     }
 
     public create(): void {
@@ -51,8 +41,12 @@ export default class Title extends Phaser.State {
         }
     }
     private addProjectiles(x: number, y: number): void {
-        this.weapon = this.add.weapon(10, 'bullet');
-        this.weapon.fireFrom.setTo(x, y, 1, 1);
+        this.weapon = this.game.add.weapon(10, 'projectile');
+        let w = this.weapon;
+        w.bulletKillType = Phaser.Weapon.KILL_WORLD_BOUNDS; // auto kills when out of world
+        w.bulletSpeed = 300;
+        w.fireRate = 50;
+        // w.track
     }
 
 }

--- a/src/states/title.ts
+++ b/src/states/title.ts
@@ -43,10 +43,10 @@ export default class Title extends Phaser.State {
         // this.game.camera.flash(0x000000, 1000);
     }
     public update(): void {
-        if (this._keys.Left.isDown){
+        if (this._keys.Left.isDown) {
             this.spaceship.RotateClockwise();
         }
-        if (this._keys.Right.isDown){
+        if (this._keys.Right.isDown) {
             this.spaceship.RotateCounterClockwise();
         }
     }


### PR DESCRIPTION
Main things I changed:

- adjust the centering using "anchor" -- using the Item image centering wasn't centering the projectile and spaceship the same way. Using game.world.centerX with anchor allowed the two images to be lined up.

- Moved the projectile code to its own class.

Currently the projectile is displayed on top of the ship -- did this so you can see the projectile. To move behind you simply need to create the Projectile object first so the Spaceship gets rendered on top of it.